### PR TITLE
docs: update README to reflect MIT license

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,4 +178,6 @@ This project follows Go standard practices and uses:
 
 ## 📄 License
 
-[License to be added]
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+Copyright (c) 2024 Beyond Identity


### PR DESCRIPTION
Replace placeholder "[License to be added]" with proper MIT License information including link to LICENSE file and copyright notice.

Fixes #10

Generated with [Claude Code](https://claude.ai/code)