### PR TITLE
fix: add missing externalId field for SCIM user creation

### DIFF
--- a/internal/bi/client.go
+++ b/internal/bi/client.go
@@ -20,6 +20,7 @@ type Client struct {
 // User represents a Beyond Identity SCIM user
 type User struct {
 	ID          string      `json:"id,omitempty"`
+	ExternalID  string      `json:"externalId"`
 	UserName    string      `json:"userName"`
 	DisplayName string      `json:"displayName"`
 	Emails      []Email     `json:"emails"`

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -205,6 +205,7 @@ func (e *Engine) ensureBIUser(email string, result *SyncResult) (string, error) 
 	displayName := extractDisplayName(email)
 
 	newUser := &bi.User{
+		ExternalID:  email,
 		UserName:    email,
 		DisplayName: displayName,
 		Emails: []bi.Email{


### PR DESCRIPTION
## Summary
• Resolves SCIM API error when creating users by adding the required `externalId` field to the User struct
• Sets the `externalId` to the user's email address during user creation, fixing sync failures

## Test plan
- [x] Verified fix resolves SCIM 400 error for missing externalId
- [x] Tested successful user creation: `pete.danner@byndid-mail.com` created with ID `2d65882b-d9a9-4f03-b809-20133a1faa21`
- [x] Confirmed sync completes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)