### PR TITLE
feat: switch to read-only scope for user directory API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         CGO_ENABLED: 0
     
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: scim-sync-${{ matrix.os }}-${{ matrix.arch }}
         path: dist/${{ steps.binary.outputs.name }}
@@ -64,7 +64,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Download all artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: dist/
     

--- a/internal/gws/client.go
+++ b/internal/gws/client.go
@@ -75,7 +75,7 @@ func NewClient(serviceAccountKeyPath, domain, superAdminEmail string) (*Client, 
 	// Create JWT config for domain-wide delegation
 	config, err := google.JWTConfigFromJSON(
 		credentialsJSON,
-		admin.AdminDirectoryUserScope,
+		admin.AdminDirectoryUserReadonlyScope,
 		admin.AdminDirectoryGroupScope,
 		admin.AdminDirectoryGroupMemberScope,
 	)

--- a/internal/setup/docs.go
+++ b/internal/setup/docs.go
@@ -143,7 +143,7 @@ server:
    - Add new API client with:
      - Client ID: (from service account)
      - OAuth Scopes: 
-       - ` + "`https://www.googleapis.com/auth/admin.directory.user`" + `
+       - ` + "`https://www.googleapis.com/auth/admin.directory.user.readonly`" + `
        - ` + "`https://www.googleapis.com/auth/admin.directory.group`" + `
        - ` + "`https://www.googleapis.com/auth/admin.directory.group.member`" + `
 


### PR DESCRIPTION
- Changed admin.directory.user to admin.directory.user.readonly
- Group scopes remain with write access for enrollment management
- Updated documentation to reflect new scope requirements

The tool only reads user data from Google Workspace, never modifies it. Group write access is still required for bi-directional sync functionality.